### PR TITLE
Add git config to test repo

### DIFF
--- a/fixtures/fixture.gitconfig
+++ b/fixtures/fixture.gitconfig
@@ -1,0 +1,4 @@
+[user]
+	name = Testy McTesterson
+	email = idontexistanythingaboutthat@email.com
+	username = idontexistanythingaboutthat


### PR DESCRIPTION
Prior to this PR, many of the tests were failing in CI, as there was
no git user configured for operations like making commits. This commit
adds a test config and updates the test setup to use that config for the
local test repo. This is a local git config that exists only for the repo and does not affect anything else on the  build machine.

Fixes #28 