### PR TITLE
Project rename and split into targeted binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
+.idea
 /target/
 **/*.rs.bk
 Cargo.lock
-/target/
-**/*.rs.bk
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
-name = "kevlar-laces-rs"
+name = "git-rsl"
 version = "0.1.0"
 authors = ["Gabriella Chronis <gchronis@polysync.io>",
-           "Jeff Weiss <jeffweiss@polysync.io>"]
+           "Jeff Weiss <jeffweiss@polysync.io>",
+           "Katie Cleary <kcleary@polysync.io>",
+           "Zachary Pierce <zacharypierce@gmail.com>"]
 
 [dependencies]
 clap = "2"
@@ -26,9 +28,18 @@ hex = "0.3.1"
 clippy = { version = "*", optional = true }
 
 [lib]
-name = "kevlar_laces"
+name = "git_rsl"
 path = "src/lib.rs"
 
 [[bin]]
 name = "kevlar-laces-rs"
-path = "src/main.rs"
+path = "src/bin/kevlar-laces-rs.rs"
+
+[[bin]]
+name = "git-secure-fetch"
+path = "src/bin/git-secure-fetch.rs"
+
+[[bin]]
+name = "git-secure-push"
+path = "src/bin/git-secure-push.rs"
+

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 
 #!/bin/bash
 
-echo "Installing kevlar-laces-rs to ~/.local/bin ..."
+echo "Installing git-rsl binaries ..."
 echo ""
 echo "Checking dependencies ..."
 
@@ -18,7 +18,7 @@ if command -v git >/dev/null 2>&1 ; then
     echo "    version: $(git --version)"
 else
     echo "Error: git not found"
-    echo "kevlar-laces is a git plugin and as such will not work without it."
+    echo "git-rsl binaries act as git plugins and as such will not work without it."
     exit -1
 fi
 
@@ -32,7 +32,7 @@ else
         echo "    version: $(gpg --version | sed -n 1p)"
     else
         echo "Error: gpg not found"
-        echo "kevlar-laces-rs utlizes GPG to verify the author of a commit."
+        echo "git-rsl utilizes GPG to verify the author of a commit."
         echo "Please install it before proceeding."
         echo "    $ apt-get install gpg2"
     fi
@@ -48,16 +48,13 @@ echo "Running tests ..."
 cargo test
 if [ $? != 0 ]
 then
-  echo "I cannot install kevlar-laces-rs in good conscience when tests are failing."
+  echo "I cannot install git-rsl in good conscience when tests are failing."
   exit -1
 fi
 echo "All tests pass. Proceeding with install ..."
 
-echo "Building binaries ..."
-cargo build
-
-echo "Creating symlink for kevlar-laces-rs binary ..."
-ln -sf `pwd`/target/debug/kevlar-laces-rs $DEST_DIR
+echo "Building and installing binaries ..."
+cargo install
 
 output=$(echo $PATH | grep -F $DEST_DIR)
 if [ $? != 0 ]
@@ -68,10 +65,6 @@ then
   echo "export PATH=\$PATH:$DEST_DIR" >> $HOME/.bashrc
   eval "export PATH=$PATH:$DEST_DIR"
 fi
-
-echo "Creating git aliases for secure-fetch and secure-push ..."
-git config --global alias.secure-push '!kevlar-laces-rs --push'
-git config --global alias.secure-fetch '!kevlar-laces-rs --fetch'
 
 echo "Installation successful. To learn about usage of this tool, run any of
 the subcommands with the '-h' flag, e.g. 'git secure-push -h'.

--- a/src/bin/git-secure-fetch.rs
+++ b/src/bin/git-secure-fetch.rs
@@ -1,0 +1,59 @@
+#[macro_use]
+extern crate clap;
+
+extern crate git_rsl;
+extern crate git2;
+
+use std::process;
+pub use git_rsl::errors::*;
+pub use git_rsl::utils::git;
+use clap::{App, Arg};
+
+fn main() {
+    let matches = App::new("git-secure-fetch")
+        .bin_name("git secure-fetch")
+        .about("Securely fetch <BRANCH> from <REMOTE> checking the reference state log to protect against metadata attacks")
+        .arg(Arg::with_name("REMOTE")
+            .help("The remote repository that is the source of the fetch operation.")
+            .takes_value(false)
+            .required(true))
+        .arg(Arg::with_name("BRANCH")
+            .help("The target branch to fetch.")
+            .takes_value(false)
+            .required(true))
+        .version(crate_version!())
+        .author(crate_authors!())
+        .get_matches();
+
+    let remote = match matches.value_of("REMOTE") {
+        None => panic!("Must supply a REMOTE argument"),
+        Some(v) => v.to_owned()
+    };
+
+    let branch = match matches.value_of("BRANCH") {
+        None => panic!("Must supply a BRANCH argument"),
+        Some(v) => v.to_owned()
+    };
+    // TODO - reduce code duplication across the top level of the binaries
+    let mut repo = git::discover_repo()
+        .expect("You don't appear to be in a git project. Please check yourself and try again");
+
+    if let Err(ref e) = git_rsl::secure_fetch_with_cleanup(&mut repo, &branch, &remote) {
+        handle_error(e);
+        process::exit(1);
+    }
+    println!("Success!")
+}
+
+
+fn handle_error(e: &Error) -> () {
+    report_error(&e);
+    match *e {
+        Error(ErrorKind::ReadError(_), _) => {
+            process::exit(1)
+        }
+        Error(_, _) => {
+            process::exit(2)
+        }
+    }
+}

--- a/src/bin/git-secure-push.rs
+++ b/src/bin/git-secure-push.rs
@@ -1,0 +1,59 @@
+#[macro_use]
+extern crate clap;
+
+extern crate git_rsl;
+extern crate git2;
+
+use std::process;
+pub use git_rsl::errors::*;
+pub use git_rsl::utils::git;
+use clap::{App, Arg};
+
+fn main() {
+    let matches = App::new("git-secure-push")
+        .bin_name("git secure-push")
+        .about("Securely push <BRANCH> to <REMOTE> while checking and updating the reference state log to protect against metadata attacks")
+        .arg(Arg::with_name("REMOTE")
+            .help("The remote repository that is the target of the push operation. (example: origin)")
+            .takes_value(false)
+            .required(true))
+        .arg(Arg::with_name("BRANCH")
+            .help("The target branch to push. (example: master)")
+            .takes_value(false)
+            .required(true))
+        .version(crate_version!())
+        .author(crate_authors!())
+        .get_matches();
+
+    let remote = match matches.value_of("REMOTE") {
+        None => panic!("Must supply a REMOTE argument"),
+        Some(v) => v.to_owned()
+    };
+
+    let branch = match matches.value_of("BRANCH") {
+        None => panic!("Must supply a BRANCH argument"),
+        Some(v) => v.to_owned()
+    };
+    // TODO - reduce code duplication across the top level of the binaries
+    let mut repo = git::discover_repo()
+        .expect("You don't appear to be in a git project. Please check yourself and try again");
+
+    if let Err(ref e) = git_rsl::secure_push_with_cleanup(&mut repo, &branch, &remote) {
+        handle_error(e);
+        process::exit(1);
+    }
+    println!("Success!")
+}
+
+
+fn handle_error(e: &Error) -> () {
+    report_error(&e);
+    match *e {
+        Error(ErrorKind::ReadError(_), _) => {
+            process::exit(1)
+        }
+        Error(_, _) => {
+            process::exit(2)
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,3 +22,13 @@ error_chain!{
         }
     }
 }
+
+pub fn report_error(e: &Error) {
+    println!("error: {}", e);
+    for e in e.iter().skip(1) {
+        println!("caused by: {}", e);
+    }
+    if let Some(backtrace) = e.backtrace() {
+        println!("backtrace: {:?}", backtrace);
+    }
+}

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -29,7 +29,7 @@ pub fn secure_fetch<'remote, 'repo: 'remote>(
         let mut counter = 5;
         'fetch: loop {
             if counter == 0 {
-                bail!("Couldn't fetch; No push entry for latest commit on target branch. It is likely that someone pushed without using kevlar-laces. Please have that developer secure-push the branch and try again.");
+                bail!("Couldn't fetch; No push entry for latest commit on target branch. It is likely that someone pushed without using git-rsl. Please have that developer secure-push the branch and try again.");
             }
             repo.fetch_rsl(&mut remote)?;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,4 @@
-extern crate kevlar_laces;
-//extern crate kevlar_laces;
+extern crate git_rsl as kevlar_laces;
 extern crate git2;
 use std::process::Command;
 use kevlar_laces::utils::test_helper::*;


### PR DESCRIPTION
Renames the library project to `git-rsl` and introduces two targeted binaries, `git-secure-fetch` and `git-secure-push`. 

The idea between having distinct binaries is that you can simply run `cargo install` on the top-level package and get both installed and instantly useable as git plugins.

The library has been updated to have more targeted entry fetch and push related entry points.  The push entry point always calls fetch first. 

 The old `main.rs` was renamed to `kevlar-laces-rs` and moved to `src/bin` as a temporary transition method. We'll likely remove it entirely.

In order to not interfere too heavily with @k-cleary 's testing work, I've left the legacy `run` method intact, though the `kevlar-laces-rs` transitional binary doesn't use it.

The README updates will follow in a coming PR.