### PR TITLE
Use fully qualified ref names in RSL push entries

### DIFF
--- a/src/push_entry.rs
+++ b/src/push_entry.rs
@@ -39,9 +39,9 @@ impl From<OidDef> for Oid {
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct PushEntry {
-    branch: String,
+    ref_name: String,
     #[serde(with = "OidDef")]
-    head: Oid,
+    oid: Oid,
     prev_hash: String,
     nonce_bag: NonceBag,
 }
@@ -60,8 +60,8 @@ impl PushEntry {
             .unwrap();
 
         PushEntry {
-            branch: String::from(branch_str), //TODO change this to be all ref_names
-            head: branch_head,
+            ref_name: format!("refs/heads/{}", branch_str),
+            oid: branch_head,
             prev_hash: prev,
             nonce_bag,
         }
@@ -71,12 +71,12 @@ impl PushEntry {
         self.prev_hash.clone()
     }
 
-    pub fn head(&self) -> Oid {
-        self.head
+    pub fn oid(&self) -> Oid {
+        self.oid
     }
 
-    pub fn branch(&self) -> &str {
-        &self.branch
+    pub fn ref_name(&self) -> &str {
+        &self.ref_name
     }
 
     pub fn get_nonce_bag(&self) -> &NonceBag {
@@ -137,8 +137,8 @@ mod tests {
         let oid = Oid::from_str("decbf2be529ab6557d5429922251e5ee36519817").unwrap();
         let entry = PushEntry {
             //related_commits: vec![oid.to_owned(), oid.to_owned()],
-            branch: String::from("branch_name"),
-            head: oid,
+            ref_name: String::from("refs/heads/branch_name"),
+            oid: oid,
             prev_hash: String::from("fwjjk42ofw093j"),
             nonce_bag: NonceBag::default(),
         };
@@ -150,8 +150,9 @@ mod tests {
 
     #[test]
     fn from_string() {
-        let string = r#"{"branch": "branch_name",
-            "head": {
+        let string = r#"{
+            "ref_name": "refs/heads/branch_name",
+            "oid": {
                 "raw": "decbf2be529ab6557d5429922251e5ee36519817"
             },
             "prev_hash": "fwjjk42ofw093j",
@@ -161,8 +162,8 @@ mod tests {
         }"#;
         let entry = PushEntry {
             //related_commits: vec![oid.to_owned(), oid.to_owned()],
-            branch: String::from("branch_name"),
-            head: Oid::from_str("decbf2be529ab6557d5429922251e5ee36519817").unwrap(),
+            ref_name: String::from("refs/heads/branch_name"),
+            oid: Oid::from_str("decbf2be529ab6557d5429922251e5ee36519817").unwrap(),
             prev_hash: String::from("fwjjk42ofw093j"),
             nonce_bag: NonceBag::default(),
         };

--- a/src/rsl.rs
+++ b/src/rsl.rs
@@ -25,7 +25,7 @@ pub fn all_push_entries_in_fetch_head(repo: &Repository, rsl: &RSL, ref_names: &
         .into_iter()
         .filter_map(
             |ref_name| match rsl.find_last_remote_push_entry_for_branch(ref_name).ok() {
-                Some(Some(pe)) => Some(pe.head()),
+                Some(Some(pe)) => Some(pe.oid()),
                 Some(None) | None => None,
             },
         )
@@ -227,14 +227,15 @@ impl<'remote, 'repo> RSL<'remote, 'repo> {
 
     pub fn find_last_remote_push_entry_for_branch(
         &self,
-        reference: &str,
+        branch: &str,
     ) -> Result<Option<PushEntry>> {
         let mut revwalk: Revwalk = self.repo.revwalk()?;
         revwalk.push(self.remote_head)?;
         let mut current = Some(self.remote_head);
+        let ref_name = format!("refs/heads/{}", branch);
         while current != None {
             if let Some(pe) = PushEntry::from_oid(self.repo, &current.unwrap())? {
-                if pe.branch() == reference {
+                if pe.ref_name() == ref_name {
                     return Ok(Some(pe));
                 }
             }


### PR DESCRIPTION
Prior to this change, the RSL implementation stored branch names directly when
serializing a push entry. This works, but we'd like RSL push entries to work
with tags as well. This commit changes the data format to use the fully
qualified branch name; i.e. what used to be 'my_pr' is now 'refs/heads/my_pr'.
This should allow adding secure push/fetch support for tags without changing the
data format.

This commit also renames some PushEntry fields to reflect their modified usage:
 - branch -> ref_name
 - head -> oid