### PR TITLE
Add ref specification to git pull

### DIFF
--- a/tests/utils/git.rs
+++ b/tests/utils/git.rs
@@ -93,7 +93,7 @@ pub fn pull(repo: &Repository, branch_name: &str) -> bool {
     Command::new("git")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .args(&["pull", "--ff-only"])
+        .args(&["pull", "--ff-only", "origin", branch_name])
         .current_dir(repo.workdir().expect("failed to get workdir of repo"))
         .status()
         .expect("failed to perform git pull")


### PR DESCRIPTION
Git pull needs to happen with a specified reference to enable a local repo pulling in a remote branch, otherwise a `git pull` may fail if the repository pulling the branch does not currently have a ref to that branch. This can cause some false positives in the rsl PBT suite.