### PR TITLE
Add tag support

### DIFF
--- a/src/bin/git-rsl-init.rs
+++ b/src/bin/git-rsl-init.rs
@@ -27,7 +27,7 @@ fn main() {
         None => panic!("Must supply a REMOTE argument"),
         Some(v) => v.to_owned(),
     };
-    // TODO - reduce code duplication across the top level of the binaries
+
     let mut repo = git::discover_repo()
         .expect("You don't appear to be in a git project. Please check yourself and try again");
 

--- a/src/bin/git-secure-fetch.rs
+++ b/src/bin/git-secure-fetch.rs
@@ -14,13 +14,13 @@ use git_rsl::{secure_fetch_with_cleanup, ReferenceName, RemoteName};
 fn main() {
     let matches = App::new("git-secure-fetch")
         .bin_name("git secure-fetch")
-        .about("Securely fetch <BRANCH> from <REMOTE> checking the reference state log to protect against metadata attacks")
+        .about("Securely fetch <REFERENCE> from <REMOTE> checking the reference state log to protect against metadata attacks")
         .arg(Arg::with_name("REMOTE")
             .help("The remote repository that is the source of the fetch operation.")
             .takes_value(false)
             .required(true))
-        .arg(Arg::with_name("BRANCH")
-            .help("The target branch to fetch.")
+        .arg(Arg::with_name("REFERENCE")
+            .help("The target ref (branch or tag) to fetch.")
             .takes_value(false)
             .required(true))
         .version(crate_version!())
@@ -32,8 +32,8 @@ fn main() {
         Some(v) => v.to_owned(),
     };
 
-    let branch = match matches.value_of("BRANCH") {
-        None => panic!("Must supply a BRANCH argument"),
+    let reference = match matches.value_of("REFERENCE") {
+        None => panic!("Must supply a REFERENCE argument"),
         Some(v) => v.to_owned(),
     };
     // TODO - reduce code duplication across the top level of the binaries
@@ -43,7 +43,7 @@ fn main() {
     if let Err(ref e) = secure_fetch_with_cleanup(
         &mut repo,
         &RemoteName::new(&remote),
-        &ReferenceName::new(&branch),
+        &ReferenceName::new(&reference),
     ) {
         handle_error(e);
         process::exit(1);

--- a/src/bin/git-secure-fetch.rs
+++ b/src/bin/git-secure-fetch.rs
@@ -9,7 +9,7 @@ use std::process;
 use clap::{App, Arg};
 use git_rsl::errors::*;
 use git_rsl::utils::git;
-use git_rsl::{secure_fetch_with_cleanup, BranchName, RemoteName};
+use git_rsl::{secure_fetch_with_cleanup, ReferenceName, RemoteName};
 
 fn main() {
     let matches = App::new("git-secure-fetch")
@@ -43,7 +43,7 @@ fn main() {
     if let Err(ref e) = secure_fetch_with_cleanup(
         &mut repo,
         &RemoteName::new(&remote),
-        &BranchName::new(&branch),
+        &ReferenceName::new(&branch),
     ) {
         handle_error(e);
         process::exit(1);

--- a/src/bin/git-secure-fetch.rs
+++ b/src/bin/git-secure-fetch.rs
@@ -36,7 +36,7 @@ fn main() {
         None => panic!("Must supply a REFERENCE argument"),
         Some(v) => v.to_owned(),
     };
-    // TODO - reduce code duplication across the top level of the binaries
+
     let mut repo = git::discover_repo()
         .expect("You don't appear to be in a git project. Please check yourself and try again");
 

--- a/src/bin/git-secure-push.rs
+++ b/src/bin/git-secure-push.rs
@@ -35,7 +35,7 @@ fn main() {
         None => panic!("Must supply a REFERENCE argument"),
         Some(v) => v.to_owned(),
     };
-    // TODO - reduce code duplication across the top level of the binaries
+
     let mut repo = git::discover_repo()
         .expect("You don't appear to be in a git project. Please check yourself and try again");
 

--- a/src/bin/git-secure-push.rs
+++ b/src/bin/git-secure-push.rs
@@ -7,7 +7,7 @@ extern crate git_rsl;
 use clap::{App, Arg};
 use git_rsl::errors::*;
 use git_rsl::utils::git;
-use git_rsl::{secure_push_with_cleanup, BranchName, RemoteName};
+use git_rsl::{secure_push_with_cleanup, ReferenceName, RemoteName};
 use std::process;
 
 fn main() {
@@ -42,7 +42,7 @@ fn main() {
     if let Err(ref e) = secure_push_with_cleanup(
         &mut repo,
         &RemoteName::new(&remote),
-        &BranchName::new(&branch),
+        &ReferenceName::new(&branch),
     ) {
         handle_error(e);
         process::exit(1);

--- a/src/bin/git-secure-push.rs
+++ b/src/bin/git-secure-push.rs
@@ -13,13 +13,13 @@ use std::process;
 fn main() {
     let matches = App::new("git-secure-push")
         .bin_name("git secure-push")
-        .about("Securely push <BRANCH> to <REMOTE> while checking and updating the reference state log to protect against metadata attacks")
+        .about("Securely push <REFERENCE> to <REMOTE> while checking and updating the reference state log to protect against metadata attacks")
         .arg(Arg::with_name("REMOTE")
             .help("The remote repository that is the target of the push operation. (example: origin)")
             .takes_value(false)
             .required(true))
-        .arg(Arg::with_name("BRANCH")
-            .help("The target branch to push. (example: master)")
+        .arg(Arg::with_name("REFERENCE")
+            .help("The target reference (branch or tag) to push.")
             .takes_value(false)
             .required(true))
         .version(crate_version!())
@@ -31,8 +31,8 @@ fn main() {
         Some(v) => v.to_owned(),
     };
 
-    let branch = match matches.value_of("BRANCH") {
-        None => panic!("Must supply a BRANCH argument"),
+    let reference = match matches.value_of("REFERENCE") {
+        None => panic!("Must supply a REFERENCE argument"),
         Some(v) => v.to_owned(),
     };
     // TODO - reduce code duplication across the top level of the binaries
@@ -42,7 +42,7 @@ fn main() {
     if let Err(ref e) = secure_push_with_cleanup(
         &mut repo,
         &RemoteName::new(&remote),
-        &ReferenceName::new(&branch),
+        &ReferenceName::new(&reference),
     ) {
         handle_error(e);
         process::exit(1);

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -35,8 +35,8 @@ pub fn secure_fetch<'remote, 'repo: 'remote>(
             let mut rsl = RSL::read(repo, &mut remote_2).chain_err(|| "couldn't read RSL")?;
 
             // reject if one of the branches has no rsl push entry
-            for branch in ref_names {
-                match rsl.find_last_remote_push_entry_for_branch(&branch) {
+            for reference in ref_names {
+                match rsl.find_last_remote_push_entry_for_reference(&reference) {
                     Ok(None) => bail!("no push records for the ref you are attempting to fetch"),
                     Err(e) => {
                         return Err(e.chain_err(|| "couldn't check that provided refs are valid"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,27 +80,27 @@ pub fn rsl_init_with_cleanup(repo: &mut Repository, remote_name: &RemoteName) ->
 pub fn secure_fetch_with_cleanup(
     repo: &mut Repository,
     remote_name: &RemoteName,
-    branch: &ReferenceName,
+    ref_name: &ReferenceName,
 ) -> Result<()> {
     ensure!(remote_name.0 == "origin", "Remote name must be \"origin\"");
     let ws = Workspace::new(repo)?;
     let mut remote = ws.repo
         .find_remote(remote_name.as_ref())
         .chain_err(|| format!("unable to find remote named {}", remote_name.as_ref()))?;
-    fetch::secure_fetch(ws.repo, &mut remote, &[branch.as_ref()])
+    fetch::secure_fetch(ws.repo, &mut remote, &[ref_name.as_ref()])
 }
 
 pub fn secure_push_with_cleanup(
     repo: &mut Repository,
     remote_name: &RemoteName,
-    branch: &ReferenceName,
+    ref_name: &ReferenceName,
 ) -> Result<()> {
     ensure!(remote_name.0 == "origin", "Remote name must be \"origin\"");
     let ws = Workspace::new(repo)?;
     let mut remote = ws.repo
         .find_remote(remote_name.as_ref())
         .chain_err(|| format!("unable to find remote named {}", remote_name.as_ref()))?;
-    push::secure_push(ws.repo, &mut remote, &[branch.as_ref()])
+    push::secure_push(ws.repo, &mut remote, &[ref_name.as_ref()])
 }
 
 pub struct Workspace<'repo> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,18 +31,18 @@ use git2::{Oid, Repository};
 use std::env;
 use std::path::PathBuf;
 
-/// Wrapper around a string reference to a branch name to reduce the odds of
+/// Wrapper around a string reference to a typed reference to reduce the odds of
 /// parameter mismatch
 #[derive(Clone, Debug)]
-pub struct BranchName<'a>(&'a str);
+pub struct ReferenceName<'a>(&'a str);
 
-impl<'a> BranchName<'a> {
-    pub fn new(source: &'a str) -> BranchName<'a> {
-        BranchName(source)
+impl<'a> ReferenceName<'a> {
+    pub fn new(source: &'a str) -> ReferenceName<'a> {
+        ReferenceName(source)
     }
 }
 
-impl<'a> AsRef<str> for BranchName<'a> {
+impl<'a> AsRef<str> for ReferenceName<'a> {
     fn as_ref(&self) -> &str {
         self.0
     }
@@ -80,7 +80,7 @@ pub fn rsl_init_with_cleanup(repo: &mut Repository, remote_name: &RemoteName) ->
 pub fn secure_fetch_with_cleanup(
     repo: &mut Repository,
     remote_name: &RemoteName,
-    branch: &BranchName,
+    branch: &ReferenceName,
 ) -> Result<()> {
     ensure!(remote_name.0 == "origin", "Remote name must be \"origin\"");
     let ws = Workspace::new(repo)?;
@@ -93,7 +93,7 @@ pub fn secure_fetch_with_cleanup(
 pub fn secure_push_with_cleanup(
     repo: &mut Repository,
     remote_name: &RemoteName,
-    branch: &BranchName,
+    branch: &ReferenceName,
 ) -> Result<()> {
     ensure!(remote_name.0 == "origin", "Remote name must be \"origin\"");
     let ws = Workspace::new(repo)?;

--- a/src/push_entry.rs
+++ b/src/push_entry.rs
@@ -2,8 +2,7 @@ use std::fmt;
 
 use crypto::digest::Digest;
 use crypto::sha3::Sha3;
-use git2::{self, BranchType, Oid, Reference, Repository};
-//use libgit2_sys::GIT_OID_RAWSZ;
+use git2::{self, Oid, Reference, Repository};
 
 use nonce_bag::NonceBag;
 
@@ -14,8 +13,11 @@ use utils;
 #[serde(remote = "Oid")]
 #[derive(Serialize, Deserialize)]
 struct OidDef {
-    #[serde(serialize_with = "utils::buffer_to_hex", deserialize_with = "utils::hex_to_buffer",
-            getter = "get_raw_oid")]
+    #[serde(
+        serialize_with = "utils::buffer_to_hex",
+        deserialize_with = "utils::hex_to_buffer",
+        getter = "get_raw_oid"
+    )]
     raw: Vec<u8>,
 }
 
@@ -53,7 +55,8 @@ impl PushEntry {
         prev: String,
         nonce_bag: NonceBag,
     ) -> PushEntry {
-        let full_ref = utils::git::get_ref_from_name(repo, branch_str).expect("failed to get reference");
+        let full_ref =
+            utils::git::get_ref_from_name(repo, branch_str).expect("failed to get reference");
         let target_oid = full_ref.target().expect("failed to get target oid");
 
         PushEntry {

--- a/src/push_entry.rs
+++ b/src/push_entry.rs
@@ -54,17 +54,19 @@ impl PushEntry {
         branch_str: &str,
         prev: String,
         nonce_bag: NonceBag,
-    ) -> PushEntry {
+    ) -> Result<PushEntry> {
+        // NONE OF THIS IS FINE bc this method doesn't return an error :P
         let full_ref =
-            utils::git::get_ref_from_name(repo, branch_str).expect("failed to get reference");
-        let target_oid = full_ref.target().expect("failed to get target oid");
+            utils::git::get_ref_from_name(repo, branch_str).ok_or("failed to get reference")?;
+        let target_oid = full_ref.target().ok_or("failed to get target oid")?;
+        let ref_name = String::from(full_ref.name().ok_or("failed to get ref's full name")?);
 
-        PushEntry {
-            ref_name: String::from(full_ref.name().expect("failed to get ref's full name")),
+        Ok(PushEntry {
+            ref_name: ref_name,
             oid: target_oid,
             prev_hash: prev,
             nonce_bag,
-        }
+        })
     }
 
     pub fn prev_hash(&self) -> String {
@@ -186,7 +188,7 @@ mod tests {
                 &"master",
                 String::from("fwjjk42ofw093j"),
                 NonceBag::default(),
-            );
+            ).unwrap();
             let oid = repo.commit_push_entry(&entry, "refs/heads/RSL").unwrap();
 
             assert_eq!(PushEntry::from_oid(&repo, &oid).unwrap().unwrap(), entry);

--- a/src/push_entry.rs
+++ b/src/push_entry.rs
@@ -53,15 +53,12 @@ impl PushEntry {
         prev: String,
         nonce_bag: NonceBag,
     ) -> PushEntry {
-        let branch_head = repo.find_branch(branch_str, BranchType::Local)
-            .unwrap()
-            .get()
-            .target()
-            .unwrap();
+        let full_ref = utils::git::get_ref_from_name(repo, branch_str).expect("failed to get reference");
+        let target_oid = full_ref.target().expect("failed to get target oid");
 
         PushEntry {
-            ref_name: format!("refs/heads/{}", branch_str),
-            oid: branch_head,
+            ref_name: String::from(full_ref.name().expect("failed to get ref's full name")),
+            oid: target_oid,
             prev_hash: prev,
             nonce_bag,
         }

--- a/src/rsl.rs
+++ b/src/rsl.rs
@@ -173,7 +173,7 @@ impl<'remote, 'repo> RSL<'remote, 'repo> {
             ref_names.first().unwrap(),
             prev_hash,
             self.nonce_bag.clone(),
-        );
+        )?;
 
         // commit new pushentry (TODO commit to detached HEAD instead of local RSL branch, in case someone else has updated and a fastforward is not possible)
         self.repo
@@ -363,7 +363,7 @@ impl<'repo> HasRSL<'repo> for Repository {
         self.commit_nonce_bag()?;
 
         // create initial bootstrapping push entry
-        let initial_pe = PushEntry::new(self, "RSL", String::from("First Push Entry"), nonce_bag);
+        let initial_pe = PushEntry::new(self, "RSL", String::from("First Push Entry"), nonce_bag)?;
         self.commit_push_entry(&initial_pe, "refs/heads/RSL")?;
 
         // push new rsl branch
@@ -563,7 +563,7 @@ mod tests {
                 &"master",                              // branch
                 String::from("hash_of_last_pushentry"), // prev
                 NonceBag::default(),
-            );
+            ).unwrap();
             let oid = repo.commit_push_entry(&entry, "refs/heads/RSL").unwrap();
 
             // we are on the correct branch with new commit at the tip
@@ -609,7 +609,7 @@ mod tests {
 
                 // create push entry manuallly and commit it to the remote rsl branch
                 let prev_hash = rsl.last_remote_push_entry.hash();
-                let push_entry = PushEntry::new(&repo, &"master", prev_hash, rsl.nonce_bag);
+                let push_entry = PushEntry::new(&repo, &"master", prev_hash, rsl.nonce_bag).unwrap();
                 let oid = repo.commit_push_entry(&push_entry, "refs/remotes/origin/RSL")
                     .unwrap();
 

--- a/src/rsl.rs
+++ b/src/rsl.rs
@@ -38,7 +38,12 @@ pub fn all_push_entries_in_fetch_head(repo: &Repository, rsl: &RSL, ref_names: &
             println!("ref_name: {:?}", ref_name);
             match repo.find_branch(&format!("origin/{}", ref_name), BranchType::Remote) {
                 Ok(branch) => branch.get().target(),
-                Err(_) => None,
+                Err(_) => {
+                    match repo.find_reference(&format!("refs/tags/{}", ref_name)) {
+                        Ok(tag_ref) => tag_ref.target(),
+                        Err(_) => None
+                    }
+                },
             }
         })
         .collect();
@@ -232,7 +237,8 @@ impl<'remote, 'repo> RSL<'remote, 'repo> {
         let mut revwalk: Revwalk = self.repo.revwalk()?;
         revwalk.push(self.remote_head)?;
         let mut current = Some(self.remote_head);
-        let ref_name = format!("refs/heads/{}", branch);
+        let reference = git::get_ref_from_name(self.repo, branch).expect("failed to get ref");
+        let  ref_name = reference.name().expect("failed to get ref name");
         while current != None {
             if let Some(pe) = PushEntry::from_oid(self.repo, &current.unwrap())? {
                 if pe.ref_name() == ref_name {

--- a/src/rsl.rs
+++ b/src/rsl.rs
@@ -38,11 +38,9 @@ pub fn all_push_entries_in_fetch_head(repo: &Repository, rsl: &RSL, ref_names: &
             println!("ref_name: {:?}", ref_name);
             match repo.find_branch(&format!("origin/{}", ref_name), BranchType::Remote) {
                 Ok(branch) => branch.get().target(),
-                Err(_) => {
-                    match repo.find_reference(&format!("refs/tags/{}", ref_name)) {
-                        Ok(tag_ref) => tag_ref.target(),
-                        Err(_) => None
-                    }
+                Err(_) => match repo.find_reference(&format!("refs/tags/{}", ref_name)) {
+                    Ok(tag_ref) => tag_ref.target(),
+                    Err(_) => None,
                 },
             }
         })
@@ -238,7 +236,7 @@ impl<'remote, 'repo> RSL<'remote, 'repo> {
         revwalk.push(self.remote_head)?;
         let mut current = Some(self.remote_head);
         let reference = git::get_ref_from_name(self.repo, reference).expect("failed to get ref");
-        let  ref_name = reference.name().expect("failed to get ref name");
+        let ref_name = reference.name().expect("failed to get ref name");
         while current != None {
             if let Some(pe) = PushEntry::from_oid(self.repo, &current.unwrap())? {
                 if pe.ref_name() == ref_name {

--- a/src/rsl.rs
+++ b/src/rsl.rs
@@ -20,18 +20,18 @@ pub enum RSLType {
 }
 
 pub fn all_push_entries_in_fetch_head(repo: &Repository, rsl: &RSL, ref_names: &[&str]) -> bool {
-    // find the last push entry for each branch
+    // find the last push entry for each reference
     let latest_push_entries: Vec<Oid> = ref_names
         .into_iter()
         .filter_map(
-            |ref_name| match rsl.find_last_remote_push_entry_for_branch(ref_name).ok() {
+            |ref_name| match rsl.find_last_remote_push_entry_for_reference(ref_name).ok() {
                 Some(Some(pe)) => Some(pe.oid()),
                 Some(None) | None => None,
             },
         )
         .collect();
 
-    // find the Oid of the tip of each remote fetched branch
+    // find the Oid of the tip of each remote fetched reference
     let fetch_heads: Vec<Oid> = ref_names
         .into_iter()
         .filter_map(|ref_name| {
@@ -230,14 +230,14 @@ impl<'remote, 'repo> RSL<'remote, 'repo> {
         Ok(())
     }
 
-    pub fn find_last_remote_push_entry_for_branch(
+    pub fn find_last_remote_push_entry_for_reference(
         &self,
-        branch: &str,
+        reference: &str,
     ) -> Result<Option<PushEntry>> {
         let mut revwalk: Revwalk = self.repo.revwalk()?;
         revwalk.push(self.remote_head)?;
         let mut current = Some(self.remote_head);
-        let reference = git::get_ref_from_name(self.repo, branch).expect("failed to get ref");
+        let reference = git::get_ref_from_name(self.repo, reference).expect("failed to get ref");
         let  ref_name = reference.name().expect("failed to get ref name");
         while current != None {
             if let Some(pe) = PushEntry::from_oid(self.repo, &current.unwrap())? {

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -267,7 +267,7 @@ pub fn fetch(
     })
 }
 
-fn get_ref_from_name<'repo>(repo: &'repo Repository, name: &str) -> Option<Reference<'repo>> {
+pub fn get_ref_from_name<'repo>(repo: &'repo Repository, name: &str) -> Option<Reference<'repo>> {
     match repo.find_branch(name, BranchType::Local) {
         Ok(branch) => Some(branch.into_reference()),
         Err(e) => { // toDo may be other errors here...

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -285,18 +285,13 @@ pub fn get_ref_from_name<'repo>(repo: &'repo Repository, name: &str) -> Option<R
 
 /// Push the branches or tags given in ref_names
 pub fn push(repo: &Repository, remote: &mut Remote, ref_names: &[&str]) -> Result<()> {
-    let refs: Vec<String> = ref_names
-        .iter()
-        .map(|name: &&str| {
-            let reference = get_ref_from_name(&repo, name).expect("failed to find reference from name");
-            String::from(reference.name().expect("failed to get full name of ref"))
-        })
-        .collect();
-
-    let mut refspecs: Vec<&str> = vec![];
-    for name in &refs {
-        refspecs.push(name)
+    let mut refs: Vec<String> = vec![];
+    for name in ref_names {
+        let reference = get_ref_from_name(&repo, name).ok_or("couldn't find reference")?;
+        refs.push(reference.name().ok_or("couldn't get name from reference")?.to_string())
     }
+
+    let refspecs: Vec<&str> = refs.iter().map(AsRef::as_ref).collect();
 
     push_refspecs(repo, remote, &refspecs)
 }

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -285,15 +285,16 @@ pub fn get_ref_from_name<'repo>(repo: &'repo Repository, name: &str) -> Option<R
 
 /// Push the branches or tags given in ref_names
 pub fn push(repo: &Repository, remote: &mut Remote, ref_names: &[&str]) -> Result<()> {
-    let mut full_names: Vec<String> = vec![];
-    for name in ref_names {
-        let reference = get_ref_from_name(&repo, name).expect("failed to find reference from name");
-        let full_name = String::from(reference.name().expect("failed to get full name of ref"));
-        full_names.push(full_name)
-    }
+    let refs: Vec<String> = ref_names
+        .iter()
+        .map(|name: &&str| {
+            let reference = get_ref_from_name(&repo, name).expect("failed to find reference from name");
+            String::from(reference.name().expect("failed to get full name of ref"))
+        })
+        .collect();
 
     let mut refspecs: Vec<&str> = vec![];
-    for name in &full_names {
+    for name in &refs {
         refspecs.push(name)
     }
 

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -1,11 +1,11 @@
-use std::{env, str};
 use std::path::Path;
+use std::{env, str};
 
 use git2;
-use git2::BranchType;
 use git2::build::CheckoutBuilder;
-use git2::{Commit, DiffOptions, FetchOptions, Oid, PushOptions, Remote, RemoteCallbacks,
-           Repository, RepositoryState, Signature, Tree, Reference};
+use git2::BranchType;
+use git2::{Commit, DiffOptions, FetchOptions, Oid, PushOptions, Reference, Remote,
+           RemoteCallbacks, Repository, RepositoryState, Signature, Tree};
 
 use git2::CredentialType;
 use git2::MergeAnalysis;
@@ -270,11 +270,13 @@ pub fn fetch(
 pub fn get_ref_from_name<'repo>(repo: &'repo Repository, name: &str) -> Option<Reference<'repo>> {
     match repo.find_branch(name, BranchType::Local) {
         Ok(branch) => Some(branch.into_reference()),
-        Err(e) => { // toDo may be other errors here...
-            let tag_ref = repo.find_reference(&format!("refs/tags/{}", name)).expect("reference not found");
+        Err(_) => {
+            let tag_ref = repo.find_reference(&format!("refs/tags/{}", name))
+                .expect("reference not found");
             if tag_ref.is_tag() {
                 Some(tag_ref)
-            } else { // not a branch or a tag
+            } else {
+                // not a branch or a tag
                 None
             }
         }

--- a/src/utils/test_helper.rs
+++ b/src/utils/test_helper.rs
@@ -10,7 +10,7 @@ use super::git;
 use fs_extra::dir::*;
 use tempdir::TempDir;
 
-use git2::Repository;
+use git2::{Repository, Object, ObjectType, Reference};
 
 pub struct Context {
     pub local: Repository,
@@ -85,6 +85,13 @@ pub fn create_file_with_text<P: AsRef<Path>>(path: P, text: &str) -> () {
     //let file_path = path.as_path();
     let mut file = File::create(path.as_ref()).unwrap();
     file.write_all(text.as_bytes()).unwrap();
+}
+
+
+pub fn tag_lightweight<'repo>(repo: &'repo Repository, tag_name: &str) -> Reference<'repo> {
+    let tag_target = &repo.head().expect("failed to get head").peel(ObjectType::Commit).expect("failed to peel");
+    let tag_oid = repo.tag_lightweight(tag_name, tag_target, false);
+    repo.find_reference(&format!("refs/tags/{}", tag_name)).expect("tag ref not found")
 }
 
 pub fn do_work_on_branch(repo: &Repository, branch_name: &str) -> () {

--- a/src/utils/test_helper.rs
+++ b/src/utils/test_helper.rs
@@ -87,12 +87,13 @@ pub fn create_file_with_text<P: AsRef<Path>>(path: P, text: &str) -> () {
     file.write_all(text.as_bytes()).unwrap();
 }
 
-pub fn tag_lightweight<'repo>(repo: &'repo Repository, tag_name: &str) -> Reference<'repo> {
+pub fn tag_latest_commit<'repo>(repo: &'repo Repository, tag_name: &str, tag_msg: &str) -> Reference<'repo> {
     let tag_target = &repo.head()
         .expect("failed to get head")
         .peel(ObjectType::Commit)
         .expect("failed to peel");
-    let _tag_oid = repo.tag_lightweight(tag_name, tag_target, false);
+    let sig = repo.signature().expect("failed to get signature");
+    let _tag_oid = repo.tag(tag_name, tag_target, &sig, tag_msg, false);
     repo.find_reference(&format!("refs/tags/{}", tag_name))
         .expect("tag ref not found")
 }

--- a/src/utils/test_helper.rs
+++ b/src/utils/test_helper.rs
@@ -10,7 +10,7 @@ use super::git;
 use fs_extra::dir::*;
 use tempdir::TempDir;
 
-use git2::{Repository, Object, ObjectType, Reference};
+use git2::{ObjectType, Reference, Repository};
 
 pub struct Context {
     pub local: Repository,
@@ -87,11 +87,14 @@ pub fn create_file_with_text<P: AsRef<Path>>(path: P, text: &str) -> () {
     file.write_all(text.as_bytes()).unwrap();
 }
 
-
 pub fn tag_lightweight<'repo>(repo: &'repo Repository, tag_name: &str) -> Reference<'repo> {
-    let tag_target = &repo.head().expect("failed to get head").peel(ObjectType::Commit).expect("failed to peel");
-    let tag_oid = repo.tag_lightweight(tag_name, tag_target, false);
-    repo.find_reference(&format!("refs/tags/{}", tag_name)).expect("tag ref not found")
+    let tag_target = &repo.head()
+        .expect("failed to get head")
+        .peel(ObjectType::Commit)
+        .expect("failed to peel");
+    let _tag_oid = repo.tag_lightweight(tag_name, tag_target, false);
+    repo.find_reference(&format!("refs/tags/{}", tag_name))
+        .expect("tag ref not found")
 }
 
 pub fn do_work_on_branch(repo: &Repository, branch_name: &str) -> () {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -62,9 +62,11 @@ sequential_test! {
             do_work_on_branch(&context.local, "refs/heads/master");
             tag_lightweight(&mut context.local, "v6.66");
 
-            assert_eq!((), git_rsl::secure_push_with_cleanup(&mut context.local, &RemoteName::new("origin"), &ReferenceName::new("v6.66")).expect("Could not run third push"));
+            assert_eq!((), git_rsl::secure_push_with_cleanup(&mut context.local, &RemoteName::new("origin"), &ReferenceName::new("v6.66")).expect("Could not push tag"));
             let remote_tag = &context.remote.find_reference("refs/tags/v6.66").expect("reference not found");
             assert!(remote_tag.is_tag());
+
+            assert_eq!((), git_rsl::secure_fetch_with_cleanup(&mut context.local, &RemoteName::new("origin"), &ReferenceName::new("v6.66")).expect("could not fetch tag"));
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -78,7 +78,7 @@ sequential_test! {
             assert_ok!(git_rsl::rsl_init_with_cleanup(&mut context.local, &remote),
                 "Could not rsl-init");
             do_work_on_branch(&context.local, "refs/heads/master");
-            tag_lightweight(&mut context.local, "v6.66");
+            tag_latest_commit(&mut context.local, "v6.66", "coolest release ever");
 
             assert_ok!(
                 git_rsl::secure_push_with_cleanup(&mut context.local, &remote, &tag), 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -60,12 +60,10 @@ sequential_test! {
             assert_eq!((), git_rsl::rsl_init_with_cleanup(&mut context.local, &RemoteName::new("origin"))
                 .expect("Could not rsl-init"));
             do_work_on_branch(&context.local, "refs/heads/master");
-            // let local_tag = tag_lightweight(&mut context.local, "v6.66");
+            tag_lightweight(&mut context.local, "v6.66");
 
-            // git_rsl::utils::git::push(&context.local, &mut context.local.find_remote("origin").expect("failed to find remote"), &["v6.66"]);
             assert_eq!((), git_rsl::secure_push_with_cleanup(&mut context.local, &RemoteName::new("origin"), &ReferenceName::new("v6.66")).expect("Could not run third push"));
             let remote_tag = &context.remote.find_reference("refs/tags/v6.66").expect("reference not found");
-            // assert_eq!(local_tag.target(), remote_tag.target())
             assert!(remote_tag.is_tag());
         }
     }

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -18,7 +18,7 @@ mod utils;
 use utils::model::{Action, Branch, Commit, Repo, State, Tool};
 
 use git_rsl::utils::test_helper::*;
-use git_rsl::{BranchName, RemoteName};
+use git_rsl::{ReferenceName, RemoteName};
 use proptest::prelude::*;
 use proptest::sample::select;
 use std::collections::HashMap;
@@ -232,7 +232,7 @@ proptest!{
             let remote_name = RemoteName::new("origin");
 
             git_rsl::rsl_init_with_cleanup(&mut context.local, &remote_name).expect("failed to init rsl");
-            git_rsl::secure_push_with_cleanup(&mut context.local, &remote_name, &BranchName::new("master")).expect("failed to secure push initial commit");
+            git_rsl::secure_push_with_cleanup(&mut context.local, &remote_name, &ReferenceName::new("master")).expect("failed to secure push initial commit");
 
             let mut locals = utils::setup_local_repos(&context, state.locals.len());
 
@@ -266,7 +266,7 @@ proptest!{
         let num_successful_rsl_actions = {
             let remote_name = RemoteName::new("origin");
             git_rsl::rsl_init_with_cleanup(&mut context.local, &remote_name).expect("failed to init rsl");
-            git_rsl::secure_push_with_cleanup(&mut context.local, &remote_name, &BranchName::new("master")).expect("failed to secure push initial commit");
+            git_rsl::secure_push_with_cleanup(&mut context.local, &remote_name, &ReferenceName::new("master")).expect("failed to secure push initial commit");
 
             let mut locals = utils::setup_local_repos(&context, state.locals.len());
 

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -29,11 +29,9 @@ pub fn repos(repo_count: Range<usize>) -> BoxedStrategy<Vec<Repo>> {
 }
 
 pub fn repo() -> BoxedStrategy<Repo> {
-    let commits = vec![
-        Commit {
-            message: "Initial Commit".to_string(),
-        },
-    ];
+    let commits = vec![Commit {
+        message: "Initial Commit".to_string(),
+    }];
 
     let mut branches = HashMap::new();
     branches.insert("master".to_string(), Branch { commits });

--- a/tests/utils/model.rs
+++ b/tests/utils/model.rs
@@ -1,5 +1,5 @@
 extern crate git_rsl;
-use self::git_rsl::BranchName;
+use self::git_rsl::ReferenceName;
 use git2::Repository;
 use names::Generator;
 use std::collections::{HashMap, HashSet};
@@ -77,11 +77,11 @@ impl Action {
             &Action::Commit(repo_num, ref message) => git::commit(&locals[repo_num], message),
             &Action::Push(repo_num, ref branch) => match tool {
                 Tool::Git => git::push(&locals[repo_num], branch),
-                Tool::RSL => rsl::push(&mut locals[repo_num], &BranchName::new(branch)),
+                Tool::RSL => rsl::push(&mut locals[repo_num], &ReferenceName::new(branch)),
             },
             &Action::Pull(repo_num, ref branch) => match tool {
                 Tool::Git => git::pull(&locals[repo_num], branch),
-                Tool::RSL => rsl::pull(&mut locals[repo_num], &BranchName::new(branch)),
+                Tool::RSL => rsl::pull(&mut locals[repo_num], &ReferenceName::new(branch)),
             },
             &Action::Branch(repo_num, ref name) => git::branch(&locals[repo_num], name),
             &Action::Checkout(repo_num, ref branch) => git::checkout(&locals[repo_num], branch),

--- a/tests/utils/rsl.rs
+++ b/tests/utils/rsl.rs
@@ -1,14 +1,14 @@
 extern crate git2;
 extern crate git_rsl;
 
-use self::git_rsl::{BranchName, RemoteName};
+use self::git_rsl::{ReferenceName, RemoteName};
 use git2::Repository;
 use git_rsl::errors::{Error, ErrorKind};
 use std::process::{Command, Stdio};
 
 const INVALID_FETCH_RSL: &str = "Couldn\'t fetch; No push entry for latest commit on target branch. It is likely that someone pushed without using git-rsl. Please have that developer secure-push the branch and try again.";
 
-pub fn push(mut repo: &mut Repository, branch_name: &BranchName) -> bool {
+pub fn push(mut repo: &mut Repository, branch_name: &ReferenceName) -> bool {
     match git_rsl::secure_push_with_cleanup(&mut repo, &RemoteName::new("origin"), branch_name) {
         Ok(()) => true,
         Err(error) => match error {
@@ -28,7 +28,7 @@ pub fn push(mut repo: &mut Repository, branch_name: &BranchName) -> bool {
     }
 }
 
-fn merge(repo: &Repository, branch_name: &BranchName) -> bool {
+fn merge(repo: &Repository, branch_name: &ReferenceName) -> bool {
     Command::new("git")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -39,7 +39,7 @@ fn merge(repo: &Repository, branch_name: &BranchName) -> bool {
         .success()
 }
 
-pub fn pull(mut repo: &mut Repository, branch_name: &BranchName) -> bool {
+pub fn pull(mut repo: &mut Repository, branch_name: &ReferenceName) -> bool {
     match git_rsl::secure_fetch_with_cleanup(&mut repo, &RemoteName::new("origin"), &branch_name) {
         Ok(()) => merge(&repo, branch_name),
         Err(error) => match error {


### PR DESCRIPTION
This PR adds support for secure-push/fetch of tags to git-rsl.

Closes #48