### PR TITLE
Reduce code duplication across binaries

### DIFF
--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -1,0 +1,37 @@
+use clap::ArgMatches;
+use git2::Repository;
+use git_rsl::errors::*;
+use git_rsl::utils::git;
+use git_rsl::{BranchName, RemoteName};
+use std::process;
+
+pub fn collect_args<'a>(
+    matches: &'a ArgMatches,
+) -> Result<(RemoteName<'a>, BranchName<'a>, Repository)> {
+    let remote = match matches.value_of("REMOTE") {
+        None => bail!("Must supply a REMOTE argument"),
+        Some(v) => RemoteName::new(v),
+    };
+
+    let branch = match matches.value_of("BRANCH") {
+        None => bail!("Must supply a BRANCH argument"),
+        Some(v) => BranchName::new(v),
+    };
+
+    let repo = match git::discover_repo() {
+        Err(_) => {
+            bail!("You don't appear to be in a git project. Please check yourself and try again")
+        }
+        Ok(repo) => repo,
+    };
+
+    Ok((remote, branch, repo))
+}
+
+pub fn handle_error(e: &Error) -> () {
+    report_error(&e);
+    match *e {
+        Error(ErrorKind::ReadError(_), _) => process::exit(1),
+        Error(_, _) => process::exit(2),
+    }
+}

--- a/src/bin/git-secure-fetch.rs
+++ b/src/bin/git-secure-fetch.rs
@@ -1,15 +1,16 @@
 #[macro_use]
 extern crate clap;
+#[macro_use]
+extern crate error_chain;
 
 extern crate git2;
 extern crate git_rsl;
 
-use std::process;
+mod cli;
 
 use clap::{App, Arg};
-use git_rsl::errors::*;
-use git_rsl::utils::git;
-use git_rsl::{secure_fetch_with_cleanup, BranchName, RemoteName};
+use cli::{collect_args, handle_error};
+use git_rsl::secure_fetch_with_cleanup;
 
 fn main() {
     let matches = App::new("git-secure-fetch")
@@ -27,34 +28,13 @@ fn main() {
         .author(crate_authors!())
         .get_matches();
 
-    let remote = match matches.value_of("REMOTE") {
-        None => panic!("Must supply a REMOTE argument"),
-        Some(v) => v.to_owned(),
+    match collect_args(&matches) {
+        Ok((remote, branch, mut repo)) => {
+            if let Err(ref e) = secure_fetch_with_cleanup(&mut repo, &remote, &branch) {
+                cli::handle_error(e);
+            }
+            println!("Success!")
+        }
+        Err(ref e) => handle_error(e),
     };
-
-    let branch = match matches.value_of("BRANCH") {
-        None => panic!("Must supply a BRANCH argument"),
-        Some(v) => v.to_owned(),
-    };
-    // TODO - reduce code duplication across the top level of the binaries
-    let mut repo = git::discover_repo()
-        .expect("You don't appear to be in a git project. Please check yourself and try again");
-
-    if let Err(ref e) = secure_fetch_with_cleanup(
-        &mut repo,
-        &RemoteName::new(&remote),
-        &BranchName::new(&branch),
-    ) {
-        handle_error(e);
-        process::exit(1);
-    }
-    println!("Success!")
-}
-
-fn handle_error(e: &Error) -> () {
-    report_error(&e);
-    match *e {
-        Error(ErrorKind::ReadError(_), _) => process::exit(1),
-        Error(_, _) => process::exit(2),
-    }
 }

--- a/src/bin/git-secure-push.rs
+++ b/src/bin/git-secure-push.rs
@@ -1,14 +1,16 @@
 #[macro_use]
 extern crate clap;
+#[macro_use]
+extern crate error_chain;
 
 extern crate git2;
 extern crate git_rsl;
 
+mod cli;
+
 use clap::{App, Arg};
-use git_rsl::errors::*;
-use git_rsl::utils::git;
-use git_rsl::{secure_push_with_cleanup, BranchName, RemoteName};
-use std::process;
+use cli::{collect_args, handle_error};
+use git_rsl::secure_push_with_cleanup;
 
 fn main() {
     let matches = App::new("git-secure-push")
@@ -26,34 +28,13 @@ fn main() {
         .author(crate_authors!())
         .get_matches();
 
-    let remote = match matches.value_of("REMOTE") {
-        None => panic!("Must supply a REMOTE argument"),
-        Some(v) => v.to_owned(),
+    match collect_args(&matches) {
+        Ok((remote, branch, mut repo)) => {
+            if let Err(ref e) = secure_push_with_cleanup(&mut repo, &remote, &branch) {
+                cli::handle_error(e);
+            }
+            println!("Success!")
+        }
+        Err(ref e) => handle_error(e),
     };
-
-    let branch = match matches.value_of("BRANCH") {
-        None => panic!("Must supply a BRANCH argument"),
-        Some(v) => v.to_owned(),
-    };
-    // TODO - reduce code duplication across the top level of the binaries
-    let mut repo = git::discover_repo()
-        .expect("You don't appear to be in a git project. Please check yourself and try again");
-
-    if let Err(ref e) = secure_push_with_cleanup(
-        &mut repo,
-        &RemoteName::new(&remote),
-        &BranchName::new(&branch),
-    ) {
-        handle_error(e);
-        process::exit(1);
-    }
-    println!("Success!")
-}
-
-fn handle_error(e: &Error) -> () {
-    report_error(&e);
-    match *e {
-        Error(ErrorKind::ReadError(_), _) => process::exit(1),
-        Error(_, _) => process::exit(2),
-    }
 }


### PR DESCRIPTION
Prior to this PR, code that was commonly used throughout the binaries was not split off into a shared module.
This PR introduces a shared module for the binaries to be able to parse App args into their expected types, discover the current repository, and error handling. This cuts down on some repeated code.
Closes #65